### PR TITLE
header data must be an array

### DIFF
--- a/Classes/Model/CatXmlImportManager.php
+++ b/Classes/Model/CatXmlImportManager.php
@@ -34,9 +34,9 @@ use TYPO3\CMS\Lang\LanguageService;
 class CatXmlImportManager
 {
     /**
-     * @var string $headerData headerData of the XML
+     * @var array $headerData headerData of the XML
      */
-    public $headerData = '';
+    public $headerData = array();
     /**
      * @var string $file filepath with XML
      */


### PR DESCRIPTION
This implicit type casting doesn't work in php 7.1 anymore.
Any attempt to import will fail with:
```
Incorrect Version of the format: 7 (required: 1.2) 
Export was taken from a diffrent Workspace, please import in this workspace to avoid problems: Current 7 (required: 7) 
'Export was taken from a diffrent language, please select correct language above! current: 1 (required: 7)
```
This is because the header contains the ste string value "7" instead of the array expected by `_isIncorrectXMLFile`